### PR TITLE
Run APT only on Debian based OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ group: deprecated-2017Q4
 services:
   - docker
 install:
-  - pip install pipenv==2018.11.26
-  - pipenv install -r test-requirements.txt
+  - pip install -r test-requirements.txt
 script:
-  - pipenv run molecule test
+  - molecule test --all
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
+### Changed
+- *[#22](https://github.com/idealista/nexus-role/issues/22) Remove Java role deployment in tests* @jnogol
+- *Remove pipenv use in Travis* @jnogol
 
 ## [1.5.0](https://github.com/idealista/nexus-role/tree/1.5.0) (2019-05-21)
 [Full Changelog](https://github.com/idealista/nexus-role/compare/1.4.0...1.5.0)

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,5 +3,4 @@
 - name: Converge
   hosts: all
   roles:
-    - java
     - nexus-role

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,0 @@
----
-- src: idealista.java_role
-  version: 4.1.0
-  name: java

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,6 +4,7 @@
     pkg: "{{ item }}"
     state: present
   with_items: "{{ nexus_required_libs }}"
+  when: ansible_os_family == "Debian"
 
 - name: NEXUS | Ensure nexus group
   group:


### PR DESCRIPTION
### Requirements

* To be able to use role also on non Debian based OS (like Centos)

### Description of the Change

Run apt step only on Debian

(can be enhanced by splitting the dependencies variable per os family, but currently I don't know about dependency for Rhel based OS)

### Benefits

### Possible Drawbacks

### Applicable Issues
