### PR TITLE
Run apt only on Debian based OS

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,6 +4,7 @@
     pkg: "{{ item }}"
     state: present
   with_items: "{{ nexus_required_libs }}"
+  when: ansible_os_family == "Debian"
 
 - name: NEXUS | Ensure nexus group
   group:


### PR DESCRIPTION
### Requirements

* To be able to use role also on non Debian based OS (like Centos)

### Description of the Change

Run apt step only on Debian

(can be enhanced by splitting the dependencies variable per os family, but currently I don't know about dependency for Rhel based OS)

### Benefits

### Possible Drawbacks

### Applicable Issues
