### PR TITLE
Add support for multiple jobs at travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ script:
 
 env:
   jobs:
-    DOCKER_IMAGE_BASE=idealista/jdk:8u265-stretch-openjdk-headless
-    DOCKER_IMAGE_BASE=idealista/jdk:8u265-buster-adoptopenjdk-headless
+    - DOCKER_IMAGE_BASE=idealista/jdk:8u265-stretch-openjdk-headless
+    - DOCKER_IMAGE_BASE=idealista/jdk:8u265-buster-adoptopenjdk-headless
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,11 @@ install:
 script:
   - molecule test --all
 
+env:
+  jobs:
+    DOCKER_IMAGE_BASE=idealista/jdk:8u265-stretch-openjdk-headless
+    DOCKER_IMAGE_BASE=idealista/jdk:8u265-buster-adoptopenjdk-headless
+
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
 ### Added 
 - [#39] *Support for nexus v3.21.2-03 and later versions.* @vicsufer
+- [#41] *Tests for Debian buster* @vicsufer
 ### Changed
 - [#39] *clean_policy variable is mandatory for repositories, set to None if no policy needed* @vicsufer
 - [#39] *change molecule image from jdk:8u222 to jdk:8u265* @vicsufer

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint:
   enabled: False
 
 platforms:
-  - name: nexus-stretch
-    image: idealista/jdk:8u265-stretch-openjdk-headless
+  - name: nexus-test
+    image: ${DOCKER_IMAGE_BASE:-idealista/jdk:8u265-stretch-openjdk-headless}
     privileged: true
     capabilities:
       - SYS_ADMIN


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Allow to set molecule base_image with an environment variable.
Add support at `.travis.yml` for multiple jobs, testing the role with Debian stretch and buster.


### Benefits
Ensure role is compatible with Debian buster.

### Possible Drawbacks
None AFIK.

### Applicable Issues

~ [#41]
