### PR TITLE
Fix no longer supported filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
+### Fix
+- *Fix no longer supported test filter syntax* @jpiron
 
 ## [2.1.0](https://github.com/idealista/nexus-role/tree/2.1.0) (2020-10-08)
 [Full Changelog](https://github.com/idealista/nexus-role/compare/2.0.1...2.1.0)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -76,10 +76,10 @@
 - name: NEXUS | First-time install admin password
   set_fact:
     current_nexus_admin_password: 'admin123'
-  when: nexus_check|failed
+  when: nexus_check is failed
 
 - name: NEXUS | Actual admin password
   set_fact:
     current_nexus_admin_password: "{{ nexus_admin_password }}"
-  when: nexus_check|success
+  when: nexus_check is success
   no_log: true

--- a/tasks/config_nexus.yml
+++ b/tasks/config_nexus.yml
@@ -85,7 +85,7 @@
   with_items:
     - "{{ nexus_default_repositories }}"
   when:
-    - nexus_check|failed
+    - nexus_check is failed
     - nexus_delete_default_repositories
 
 - name: NEXUS | Delete default blobstore
@@ -93,7 +93,7 @@
   with_items:
     - default
   when:
-    - nexus_check|failed
+    - nexus_check is failed
     - nexus_delete_default_blobstore
 
 - block:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,7 +44,7 @@
     name: nexus
     state: stopped
   when:
-    - nexus_check|success
+    - nexus_check is success
     - nexus_force_reinstall or nexus_version == "latest" or nexus_check.content|b64decode != nexus_version
 
 - name: NEXUS | Untar nexus
@@ -55,7 +55,7 @@
     dest: "{{ nexus_installation_path }}"
     owner: "{{ nexus_user }}"
     group: "{{ nexus_group }}"
-  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check|failed or nexus_check.content|b64decode != nexus_version
+  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check is failed or nexus_check.content|b64decode != nexus_version
 
 - name: NEXUS | Fix permissions
   file:
@@ -63,7 +63,7 @@
     owner: "{{ nexus_user }}"
     group: "{{ nexus_group }}"
     recurse: yes
-  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check|failed or nexus_check.content|b64decode != nexus_version
+  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check is failed or nexus_check.content|b64decode != nexus_version
 
 - name: NEXUS | Set version file
   copy:
@@ -71,7 +71,7 @@
     dest: "{{ nexus_installation_path }}/VERSION"
     owner: "{{ nexus_user }}"
     group: "{{ nexus_group }}"
-  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check|failed or nexus_check.content|b64decode != nexus_version
+  when: nexus_force_reinstall or nexus_version == "latest" or nexus_check is failed or nexus_check.content|b64decode != nexus_version
 
 - name: NEXUS | Copy Daemon script
   template:


### PR DESCRIPTION
### Description of the Change

Use test syntax instead of filter one for tests.
Using Jinja tests as filter is deprecated since Ansible 2.5 and support has
been removed since Ansible 2.9.
See: https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters

### Benefits

Provides support for Ansible 2.9+

### Possible Drawbacks

None I am aware of.

### Applicable Issues

None.