### PR TITLE
Fix Nexus URLs in uri module calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
+### Fix
+- [#29] *Fix Nexus URLs in uri module calls* @jpiron
 
 ## [2.1.0](https://github.com/idealista/nexus-role/tree/2.1.0) (2020-10-08)
 [Full Changelog](https://github.com/idealista/nexus-role/compare/2.0.1...2.1.0)

--- a/tasks/script/declare_script.yml
+++ b/tasks/script/declare_script.yml
@@ -2,7 +2,7 @@
 
 - name: NEXUS | Removing previously Groovy script {{ item }}
   uri:
-    url: "http://localhost:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script/{{ item | regex_replace('/', '_') }}"
+    url: "http://{{ nexus_host }}:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script/{{ item | regex_replace('/', '_') }}"
     user: admin
     password: "{{ current_nexus_admin_password }}"
     method: DELETE
@@ -11,7 +11,7 @@
 
 - name: NEXUS | Declaring Groovy script {{ item }}
   uri:
-    url: "http://localhost:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script"
+    url: "http://{{ nexus_host }}:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script"
     user: admin
     password: "{{ current_nexus_admin_password }}"
     body_format: json

--- a/tasks/script/run_script.yml
+++ b/tasks/script/run_script.yml
@@ -2,7 +2,7 @@
 
 - name: NEXUS | Calling Groovy script {{ script_name }}
   uri:
-    url: "http://localhost:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script/{{ script_name }}/run"
+    url: "http://{{ nexus_host }}:{{ nexus_port }}{{ nexus_context_path }}service/rest/v1/script/{{ script_name }}/run"
     user: admin
     password: "{{ current_nexus_admin_password }}"
     headers:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -20,7 +20,7 @@
 
 - name: NEXUS | Waiting for Nexus service to be ready
   uri:
-    url: "http://localhost:{{ nexus_port }}{{ nexus_context_path }}"
+    url: "http://{{ nexus_host }}:{{ nexus_port }}{{ nexus_context_path }}"
     status_code: 200
   register: result
   until: result.status == 200


### PR DESCRIPTION
### Description of the Change

Nexus might not be listening on the localhost interface leading to role
failures. Using nexus_host instead of localhost ensures uri modules will
use the proper Nexus URL.

### Benefits

Fix the role when `nexus_host` uses a values that is not `localhost`

### Possible Drawbacks

None I am aware of.

### Applicable Issues

Fixes https://github.com/idealista/nexus-role/issues/29
