### PR TITLE
[#78] Allow LDAP dynamic group type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ### Added
 
-- *[#78](https://github.com/idealista/nexus-role/issues/78)* Add option to allow LDAP dynamic group type
+- *[#78](https://github.com/idealista/nexus-role/issues/78)* Add option to allow LDAP dynamic group type* @mgnavarrete
 
 ## [2.3.2](https://github.com/idealista/nexus-role/tree/2.3.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
 
+### Added
+
+- *[#78](https://github.com/idealista/nexus-role/issues/78)* Add option to allow LDAP dynamic group type
+
 ## [2.3.2](https://github.com/idealista/nexus-role/tree/2.3.2)
 
 [Full Changelog](https://github.com/idealista/nexus-role/compare/2.3.1...2.3.2)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,8 +64,8 @@ nexus_ldap_configs:
     user_real_name_attribute: cn
     user_email_attribute: mail
     user_subtree: true
-    map_groups_as_roles: true
-    #group_type_dynamic: true
+    map_groups_as_roles: false
+    group_type_dynamic: false
     user_member_of_attribute: memberOf
     group_base_dn: cn=builtin
     group_object_class: group

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,9 @@ nexus_ldap_configs:
     user_real_name_attribute: cn
     user_email_attribute: mail
     user_subtree: true
-    map_groups_as_roles: false
+    map_groups_as_roles: true
+    #group_type_dynamic: true
+    user_member_of_attribute: memberOf
     group_base_dn: cn=builtin
     group_object_class: group
     group_id_attribute: sAMAccountName

--- a/files/scripts/security/ldap.groovy
+++ b/files/scripts/security/ldap.groovy
@@ -49,13 +49,18 @@ mapping.setEmailAddressAttribute(parsed_args.user_email_attribute)
 mapping.setUserSubtree(parsed_args.user_subtree)
 
 if (parsed_args.map_groups_as_roles) {
-    mapping.setLdapGroupsAsRoles(true)
-    mapping.setGroupBaseDn(parsed_args.group_base_dn)
-    mapping.setGroupObjectClass(parsed_args.group_object_class)
-    mapping.setGroupIdAttribute(parsed_args.group_id_attribute)
-    mapping.setGroupMemberAttribute(parsed_args.group_member_attribute)
-    mapping.setGroupMemberFormat(parsed_args.group_member_format)
-    mapping.setGroupSubtree(parsed_args.group_subtree)
+    if (parsed_args.group_type_dynamic) {
+        mapping.setLdapGroupsAsRoles(true)
+        mapping.setUserMemberOfAttribute(parsed_args.user_member_of_attribute)
+    } else {
+        mapping.setLdapGroupsAsRoles(true)
+        mapping.setGroupBaseDn(parsed_args.group_base_dn)
+        mapping.setGroupObjectClass(parsed_args.group_object_class)
+        mapping.setGroupIdAttribute(parsed_args.group_id_attribute)
+        mapping.setGroupMemberAttribute(parsed_args.group_member_attribute)
+        mapping.setGroupMemberFormat(parsed_args.group_member_format)
+        mapping.setGroupSubtree(parsed_args.group_subtree)
+    }
 }
 
 ldapConfig.setMapping(mapping)

--- a/tasks/action/security/ldap.yml
+++ b/tasks/action/security/ldap.yml
@@ -21,6 +21,8 @@
       user_email_attribute: "{{ item.user_email_attribute }}"
       user_subtree: "{{ item.user_subtree }}"
       map_groups_as_roles: "{{ item.map_groups_as_roles }}"
+      group_type_dynamic: "{{ item.group_type_dynamic | default(false)}}"
+      user_member_of_attribute: "{{ item.user_member_of_attribute | default('') }}"
       group_base_dn: "{{ item.group_base_dn | default('') }}"
       group_object_class: "{{ item.group_object_class | default('') }}"
       group_id_attribute: "{{ item.group_id_attribute  | default('') }}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Two variables have been added to allow dynamic LDAP groups selection. If group_type_dynamic is false or not set, LDAP group type will be static. If it is true, then it will be dynamic.

### Benefits

Allow LDAP dynamic group type
