### PR TITLE
[FEATURE-#83] - Inaccessibility of RealmConfiguration.getConfiguration() Method in Nexus Version >3.6 (#84)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ script:
 
 env:
   jobs:
-    - DOCKER_IMAGE_BASE=idealista/jdk:8u265-stretch-openjdk-headless
-    - DOCKER_IMAGE_BASE=idealista/jdk:8u265-buster-adoptopenjdk-headless
-    - DOCKER_IMAGE_BASE=idealista/jdk:8u292-bullseye-adoptopenjdk-headless
+    # - DOCKER_IMAGE_BASE=idealista/jdk:8u265-stretch-openjdk-headless
+    - DOCKER_IMAGE_BASE=idealista/jdk:8u382-buster-temurin-jdk
+    - DOCKER_IMAGE_BASE=idealista/jdk:8u382-bullseye-temurin-jdk
 
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/nexus-role/tree/develop)
 
+### Added
+- *[#83](https://github.com/idealista/nexus-role/issues/83)* Remove unnecessary access org.sonatype.nexus.security.realm.RealmConfiguration to allow use nexus newer versions * @ygomez
+
 ## [2.4.0](https://github.com/idealista/nexus-role/tree/2.4.0)
 
 [Full Changelog](https://github.com/idealista/nexus-role/compare/2.3.2...2.4.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,10 @@ nexus_version: latest # Or: 3.27.0-03, 3.26.0-04, ..., 3.21.2-03
 nexus_user: nexus
 nexus_group: nexus
 
+## Operative system 
+os : unix # options: unix/win64/mac
+java_version: 8
+
 # Service options
 
 ## start on boot
@@ -257,7 +261,7 @@ nexus_repositories_raw:
 ## COMPOSER
 nexus_composer_enable: false
 nexus_repositories_composer:
-  plugin_version: 0.0.7
+  plugin_version: 0.0.29
   proxy:
     - name: composer-proxy
       remote_url: https://packagist.org/

--- a/files/scripts/security/realm.groovy
+++ b/files/scripts/security/realm.groovy
@@ -1,9 +1,7 @@
 import groovy.json.JsonSlurper
 import org.sonatype.nexus.security.realm.RealmManager
-import org.sonatype.nexus.security.realm.RealmConfiguration
 
 parsed_args = new JsonSlurper().parseText(args)
 
 def realmManager = container.lookup(RealmManager.class.getName());
-RealmConfiguration realmConfig = realmManager.getConfiguration()
 realmManager.enableRealm(parsed_args.name, parsed_args.enabled && parsed_args.enabled.toBoolean())

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,9 +7,9 @@ FROM {{ item.image }}
 {% endif %}
 
 
-{% if item.image == 'idealista/jdk:8u292-bullseye-adoptopenjdk-headless' %}
+{% if item.image == 'idealista/jdk:8u382-bullseye-temurin-jdk' %}
 RUN if [ $(command -v apt-get) ]; then apt-get update  && apt-get upgrade -y && apt-get install -y python3 sudo bash ca-certificates systemd systemd-sysv && apt-get clean ; fi
-{% elif item.image == 'idealista/jdk:8u265-buster-adoptopenjdk-headless' %}
+{% elif item.image == 'idealista/jdk:8u382-buster-temurin-jdk' %}
 RUN if [ $(command -v apt-get) ]; then apt-get update --allow-releaseinfo-change && apt-get upgrade -y && apt-get install -y python3 sudo bash ca-certificates systemd systemd-sysv && apt-get clean ; fi
 {% else %}
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates systemd systemd-sysv && apt-get clean; fi

--- a/molecule/default/group_vars/nexus/main.yml
+++ b/molecule/default/group_vars/nexus/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## NEXUS
-nexus_version: 3.37.3-02
+nexus_version: 3.68.0-04
 nexus_host: 0.0.0.0
 nexus_port: 8081
 nexus_docker_enable: true
@@ -207,7 +207,7 @@ nexus_repositories_raw:
 
 ## COMPOSER
 nexus_repositories_composer:
-  plugin_version: 0.0.18
+  plugin_version: 0.0.29
   proxy:
     - name: composer-proxy
       remote_url: https://packagist.org/

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 
 platforms:
   - name: nexus-test
-    image: ${DOCKER_BASE_IMAGE:-idealista/jdk:8u292-bullseye-adoptopenjdk-headless}
+    image: ${DOCKER_BASE_IMAGE:-idealista/jdk:8u382-bullseye-temurin-jdk}
     privileged: false
     capabilities:
       - SYS_ADMIN

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ molecule==3.5.2
 molecule-docker==1.1.0
 molecule-goss==1.1  
 docker==5.0.3
+urllib3<2.0.0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ nexus_required_libs:
   - unzip
 
 nexus_mirror: https://download.sonatype.com/nexus/3
-nexus_package_name: "{{ (nexus_version == 'latest') | ternary('', 'nexus-') }}{{ nexus_version }}-unix"
+nexus_package_name: "{{ (nexus_version == 'latest') | ternary('', 'nexus-') }}{{ nexus_version }}{{ (nexus_version is version('3.66.0', '>')) | ternary('-java' + java_version | string, '') }}-{{ os }}"
 nexus_package: "{{ nexus_package_name }}.tar.gz"
 nexus_sources_url: "{{ nexus_mirror }}/{{ nexus_package }}"
 


### PR DESCRIPTION
### Description of the Change

This pull request is for solving ISSUE #83 

In the newer versions of Nexus (version >3.6), the `getConfiguration() `method from `org.sonatype.nexus.security.realm.RealmConfiguration` is no longer accessible (private method). This change is causing the following error:

```
{
  "name" : "security_realm",
  "result" : "javax.script.ScriptException: groovy.lang.MissingMethodException: No signature of method: org.sonatype..security.internal.RealmManagerImpl$$EnhancerByGuice$$4cc466e.getConfiguration() is applicable for argument types: () values: []"
}
```

`realm.groovy` ( files/scripts/security/realm.groovy) script is used to enable or disable a security realm in Nexus Repository Manager. 

Currently the script is retrieving the ` RealConfiguration`  object from the `RealmManager` before enabling or disabling the realm. However, this is not necessary for the operation and can cause an error in newer versions of Nexus, as the `getConfiguration()` method is not being accessible  in the `RealmManager` interface. The change is removing that unnecessary part of the code 

### Benefits

This change allows to use newer version of nexus ( >3.6)

### Possible Drawbacks

Not drawbacks found

### Applicable Issues

#83 